### PR TITLE
dayjs 제거, 모든 Date를 한국 시간 기준으로 설정

### DIFF
--- a/src/app/api/queries/queryKey.ts
+++ b/src/app/api/queries/queryKey.ts
@@ -1,11 +1,11 @@
-import { getCurrentDate, getCurrentDateAndHour } from '@/utils/date';
+import { getFormattedLocaleDate } from '@/utils/date';
 
 export const QUERY_KEYS = {
   SHOPPING: {
     LIST: (query: string, display = 10) => ['SHOPPING_LIST', query, display],
   },
   WEATHER: {
-    CURRENT: ['WEATHER_CURRENT', getCurrentDateAndHour()],
-    LIST: ['WEATHER_LIST', getCurrentDate()],
+    CURRENT: ['WEATHER_CURRENT', getFormattedLocaleDate({ includeHour: true })],
+    LIST: ['WEATHER_LIST', getFormattedLocaleDate()],
   },
 } as const;

--- a/src/components/Weather/Background/WeatherBackground.tsx
+++ b/src/components/Weather/Background/WeatherBackground.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-
 import { useGetCurrentWeather } from '@/hooks/apis/getWeatherList';
-import { getDayTime } from '@/utils/date';
+import { useBackground } from '@/hooks/useBackground';
 
 import { Cloud, Rain, Snow, Stars, Sun } from './Animation';
-import { getCurrentSkyColor, getDefaultSkyColor } from './utils';
 
 export default function WeatherBackground() {
-  const [isDay, setIsDay] = useState(true);
-  const [skyColor, setSkyColor] = useState(getDefaultSkyColor());
   const { data: currentWeather } = useGetCurrentWeather();
+  const { dayTime, currentSkyColor } = useBackground();
+
+  const isNight = dayTime === 'night';
 
   const weatherSummary = currentWeather?.summary;
 
@@ -22,20 +20,15 @@ export default function WeatherBackground() {
         ? 30
         : 0;
 
-  useEffect(() => {
-    setIsDay(getDayTime() === 'day');
-    setSkyColor(getCurrentSkyColor());
-  }, []);
-
   return (
     <div
       className='w-full text-lg h-full min-h-screen absolute top-0 left-0 pb-navigation'
       style={{
-        background: `linear-gradient(${skyColor})`,
+        background: `linear-gradient(${currentSkyColor})`,
       }}
     >
-      {isDay && weatherSummary === 'clear' && <Sun UVindex={60} />}
-      {!isDay && <Stars />}
+      {!isNight && weatherSummary === 'clear' && <Sun UVindex={60} />}
+      {isNight && <Stars />}
       {cloudCover > 0 && <Cloud cloudCover={cloudCover} />}
       {weatherSummary === 'rain' && <Rain />}
       {weatherSummary === 'snow' && <Snow />}

--- a/src/components/Weather/Background/utils.ts
+++ b/src/components/Weather/Background/utils.ts
@@ -1,5 +1,3 @@
-import { getDayTime } from '@/utils/date';
-
 const DAYTIME_COLOR = {
   sunrise: 'to bottom, #1B2A4A, #7D6180',
   sunset: 'to bottom, #094F91, #E6D6C3',
@@ -8,9 +6,7 @@ const DAYTIME_COLOR = {
   default: 'to bottom, #072A57, #6F87A5',
 };
 
-export const getCurrentSkyColor = () => {
-  const dayTime = getDayTime();
-
+export const getCurrentSkyColor = (dayTime: keyof typeof DAYTIME_COLOR) => {
   return DAYTIME_COLOR[dayTime];
 };
 

--- a/src/hooks/useBackground.ts
+++ b/src/hooks/useBackground.ts
@@ -1,0 +1,12 @@
+import { getCurrentSkyColor } from '@/components/Weather/Background/utils';
+import { getCurrentDate, getDayTime } from '@/utils/date';
+
+export const useBackground = () => {
+  const currentDate = getCurrentDate();
+  const currentHour = currentDate.getHours();
+
+  const dayTime = getDayTime(currentHour);
+  const currentSkyColor = getCurrentSkyColor(dayTime);
+
+  return { currentDate, dayTime, currentSkyColor };
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,37 +1,19 @@
-import 'dayjs/locale/ko';
-
-import dayjs from 'dayjs';
-
-dayjs.locale('ko');
-
-export const convertDateByFormat = (date: dayjs.Dayjs, dateFormat: string) => {
-  return date.format(dateFormat);
+// 모든 시간은 한국 기준으로 변환됩니다.
+export const convertToKRDate = (date: Date) => {
+  const utc = date.getTime() + date.getTimezoneOffset() * 60 * 1000;
+  const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+  return new Date(utc + KR_TIME_DIFF);
 };
 
-export const convertTimestampToDate = (
-  timestamp: number,
-  dateFormat?: string,
-) => {
-  const currentDate = dayjs(timestamp * 1000);
+/*
+ * 현재 시간과 관련된 함수들입니다.
+ */
 
-  return convertDateByFormat(currentDate, dateFormat ?? 'MM/DD (ddd)');
+export const getCurrentDate = () => {
+  return convertToKRDate(new Date());
 };
 
-export const isToday = (timestamp: number) => {
-  const today = dayjs();
-  const currentDate = dayjs(timestamp * 1000);
-
-  return (
-    today.year() === currentDate.year() &&
-    today.month() === currentDate.month() &&
-    today.date() === currentDate.date()
-  );
-};
-
-export const getDayTime = () => {
-  const currentDate = dayjs();
-  const currentHour = currentDate.hour();
-
+export const getDayTime = (currentHour: number) => {
   if (currentHour >= 5 && currentHour <= 6) {
     return 'sunrise';
   } else if (currentHour >= 7 && currentHour <= 17) {
@@ -43,12 +25,73 @@ export const getDayTime = () => {
   }
 };
 
-export const getCurrentDate = () => {
-  const currentDate = dayjs();
-  return convertDateByFormat(currentDate, 'YYYY-MM-DD');
+/*
+ * Timestamp를 날짜로 변환하는 함수입니다.
+ */
+
+export const getTimestampDate = (timestamp: number) => {
+  return convertToKRDate(new Date(timestamp * 1000));
 };
 
-export const getCurrentDateAndHour = () => {
-  const currentDate = dayjs();
-  return convertDateByFormat(currentDate, 'YYYY-MM-DD HH:00');
+/*
+ * timestamp가 오늘인지 확인하는 함수입니다.
+ */
+
+export const isToday = (timestamp: number) => {
+  const currentDate = getCurrentDate();
+  const timestampDate = getTimestampDate(timestamp);
+
+  return (
+    currentDate.getFullYear() === timestampDate.getFullYear() &&
+    currentDate.getMonth() === timestampDate.getMonth() &&
+    currentDate.getDate() === timestampDate.getDate()
+  );
+};
+
+/*
+ * 날짜를 포맷에 맞춰 변경하는 함수들입니다.
+ */
+
+export const getFormattedLocaleDate = ({
+  includeHour = false,
+  includeMinutes = false,
+}: {
+  includeHour?: boolean;
+  includeMinutes?: boolean;
+} = {}) => {
+  const currentDate = getCurrentDate();
+
+  const options: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  };
+
+  if (includeHour) {
+    options.hour = '2-digit';
+  }
+
+  if (includeMinutes) {
+    options.minute = '2-digit';
+  }
+
+  return currentDate.toLocaleDateString('ko-KR', options);
+};
+
+export const convertTimestampToDate = (timestamp: number) => {
+  const currentDate = getTimestampDate(timestamp);
+
+  const dateStr = currentDate
+    .toLocaleDateString('ko-KR', {
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replace(/\./g, '')
+    .replace(/ /g, '/');
+
+  const dayStr = currentDate.toLocaleDateString('ko-KR', {
+    weekday: 'short',
+  });
+
+  return `${dateStr} (${dayStr})`;
 };


### PR DESCRIPTION
## 📝 설명

<!-- 작업에 대한 설명입니다. -->

서버에서 렌더링 된 시간과 클라이언트에서 렌더링 된 시간이
다른 문제로 Mismatch Error가 발생하였습니다.

따라서 모든 **dayjs의 timezone 설정을 제거**하고
**utc 시간에 9시간을 더한 변환 함수**를 활용하여 시간을 통일하였습니다.

## ✅ 작업 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 💻 작업 내용

<!-- 본문을 입력하세요. -->

### 기능 추가 내용
- timezoneOffset을 이용한 시간 변환 함수 추가

### 리팩토링 내용

- date 관련 모든 유틸 함수를 해당 함수를 사용하도록 리팩토링
- Background UI 계산과 관련된 변수들을 useBackground hook으로 응집
